### PR TITLE
Add .npmrc to fix Dependabot registry error

### DIFF
--- a/.npmrc
+++ b/.npmrc
@@ -1,0 +1,1 @@
+registry=https://registry.npmjs.org


### PR DESCRIPTION
## Summary
- Adds a `.npmrc` file pointing to the public npm registry
- Fixes Dependabot error: *"unable to resolve a private registry configuration for npm.pkg.github.com"*
- Dependabot was treating scoped packages (`@supabase/`, `@radix-ui/`, etc.) as potential GitHub Packages and couldn't proceed without explicit registry config

## Test plan
- [ ] Merge and confirm Dependabot can open security update PRs without the registry error

🤖 Generated with [Claude Code](https://claude.com/claude-code)